### PR TITLE
Upgrade to NodeJS 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: 'Whether the action should log the input and output content'
     default: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes ops issue here for removing deprecation warnings from CI : https://github.com/fac/platform-issues/issues/2162



- Node 12 is being deprecated, upgrade to Node 16
